### PR TITLE
Added support for LuaJIT 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ee5_base64
 ==========
-Lua 5.2 base64 encoding and decoding
+Lua 5.2 and LuaJIT 2.x base64 encoding and decoding
 
-This module is written for Lua 5.2 and likely could be used in 5.1 using the [LuaRocks](http://luarocks.org/) [bit32](https://raw.github.com/hishamhm/lua-compat-5.2/bitlib-5.2.2/lbitlib.c) backport. **I** have not tested on 5.1 and likely never will.
+This module is written for Lua 5.2 (and was ported to LuaJIT 2.x) and likely could be used in 5.1 using the [LuaRocks](http://luarocks.org/) [bit32](https://raw.github.com/hishamhm/lua-compat-5.2/bitlib-5.2.2/lbitlib.c) backport. **I** have not tested on 5.1 and likely never will.
 
 This module "exports" 3 methods with various "overloads" that allow interaction with the encoding / decoding routines. Default is to encode and decode as RFC 2045. This implementation is not strict 2045. _Line breaking is the responsibility of the user._
 


### PR DESCRIPTION
Hi -- love your base64 library, but wanted to use it under LuaJIT instead of Lua 5.2. I found a snippet that expressed bit32.extract in terms of LuaJIT's built-in bit library and changed formatting in a couple of places that threw errors for ambiguity in LuaJIT (and that would throw errors in 5.1 as well, I think), and it all seems to work fine. And very, very fast. :)

Thanks for making the library available. I ran the tests using LuaJIT and they still passed. And I did a quick benchmark where I encoded 1Mb of random values, and the "real" time reported was around 0.089s on each run, and under Lua 5.2 on the same system I'm seeing between 0.330s and 0.341s, so it's almost 4x faster under LuaJIT, which is typical for something like this.

Thanks again,

Tim
